### PR TITLE
Added ability to color molecules

### DIFF
--- a/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
+++ b/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
@@ -13,7 +13,7 @@ import java.util.Random;
 public enum EnumMolecule {
     cellulose(0, "Cellulose", 0, 1, 0, 0, 0.25F, 0, new Element(C, 6), new Element(H, 10), new Element(O, 5)),
     water(1, "Water", 0, 0, 1, 0, 0, 1, new Element(H, 2), new Element(O)),
-    carbonDioxide(2, "Carbon Dioxide", new Element(C), new Element(O, 2)),
+    carbonDioxide(2, "Carbon Dioxide", 0.5F, 0.5F, 0.5F, 0.25F, 0.25F, 0.25F, new Element(C), new Element(O, 2)),
     nitrogenDioxide(3, "Nitrogen Dioxide", new Element(N), new Element(O, 2)),
     toluene(4, "Toluene", new Element(C, 7), new Element(H, 8)),
     potassiumNitrate(5, "Potassium Nitrate", new Element(K), new Element(N), new Element(O, 3)),

--- a/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
+++ b/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
@@ -16,7 +16,7 @@ public enum EnumMolecule {
     carbonDioxide(2, "Carbon Dioxide", 0.5F, 0.5F, 0.5F, 0.25F, 0.25F, 0.25F, new Element(C), new Element(O, 2)),
     nitrogenDioxide(3, "Nitrogen Dioxide", 1, 0.65F, 0, 0.5F, 0.1412F, 0.1843F, new Element(N), new Element(O, 2)),
     toluene(4, "Toluene", 1, 1, 1, 0.8F, 0.8F, 0.8F, new Element(C, 7), new Element(H, 8)),
-    potassiumNitrate(5, "Potassium Nitrate", new Element(K), new Element(N), new Element(O, 3)),
+    potassiumNitrate(5, "Potassium Nitrate", 0.9F, 0.9F, 0.9F, 0.8F, 0.8F, 0.8F, new Element(K), new Element(N), new Element(O, 3)),
     tnt(6, "Trinitrotoluene", new Element(C, 6), new Element(H, 2), new Molecule(nitrogenDioxide, 3), new Molecule(toluene)),
     siliconDioxide(7, "Silicon Dioxide", new Element(Si), new Element(O, 2)),
     calcite(8, "Calcite", new Element(Ca), new Element(C), new Element(O, 3)),

--- a/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
+++ b/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
@@ -127,7 +127,6 @@ public enum EnumMolecule {
     private final String descriptiveName;
     private final ArrayList<Chemical> components;
     private int id;
-    private final Random random = new Random(id);
     public float red;
     public float green;
     public float blue;

--- a/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
+++ b/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
@@ -17,7 +17,7 @@ public enum EnumMolecule {
     nitrogenDioxide(3, "Nitrogen Dioxide", 1, 0.65F, 0, 0.5F, 0.1412F, 0.1843F, new Element(N), new Element(O, 2)),
     toluene(4, "Toluene", 1, 1, 1, 0.8F, 0.8F, 0.8F, new Element(C, 7), new Element(H, 8)),
     potassiumNitrate(5, "Potassium Nitrate", 0.9F, 0.9F, 0.9F, 0.8F, 0.8F, 0.8F, new Element(K), new Element(N), new Element(O, 3)),
-    tnt(6, "Trinitrotoluene", new Element(C, 6), new Element(H, 2), new Molecule(nitrogenDioxide, 3), new Molecule(toluene)),
+    tnt(6, "Trinitrotoluene", 1, 1, 0, 1, 0.65F, 0, new Element(C, 6), new Element(H, 2), new Molecule(nitrogenDioxide, 3), new Molecule(toluene)),
     siliconDioxide(7, "Silicon Dioxide", new Element(Si), new Element(O, 2)),
     calcite(8, "Calcite", new Element(Ca), new Element(C), new Element(O, 3)),
     pyrite(9, "Pyrite", new Element(Fe), new Element(S, 2)),

--- a/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
+++ b/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
@@ -15,7 +15,7 @@ public enum EnumMolecule {
     water(1, "Water", 0, 0, 1, 0, 0, 1, new Element(H, 2), new Element(O)),
     carbonDioxide(2, "Carbon Dioxide", 0.5F, 0.5F, 0.5F, 0.25F, 0.25F, 0.25F, new Element(C), new Element(O, 2)),
     nitrogenDioxide(3, "Nitrogen Dioxide", 1, 0.65F, 0, 0.5F, 0.1412F, 0.1843F, new Element(N), new Element(O, 2)),
-    toluene(4, "Toluene", new Element(C, 7), new Element(H, 8)),
+    toluene(4, "Toluene", 1, 1, 1, 0.8F, 0.8F, 0.8F, new Element(C, 7), new Element(H, 8)),
     potassiumNitrate(5, "Potassium Nitrate", new Element(K), new Element(N), new Element(O, 3)),
     tnt(6, "Trinitrotoluene", new Element(C, 6), new Element(H, 2), new Molecule(nitrogenDioxide, 3), new Molecule(toluene)),
     siliconDioxide(7, "Silicon Dioxide", new Element(Si), new Element(O, 2)),

--- a/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
+++ b/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
@@ -11,7 +11,7 @@ import java.util.Random;
 
 // MOLECULE IDS MUST BE CONTINIOUS OTHERWISE THE ARRAY WILL BE MISALIGNED.
 public enum EnumMolecule {
-    cellulose(0, "Cellulose", new Element(C, 6), new Element(H, 10), new Element(O, 5)),
+    cellulose(0, "Cellulose", 0, 1, 0, 0, 0.25F, 0, new Element(C, 6), new Element(H, 10), new Element(O, 5)),
     water(1, "Water", 0, 0, 1, 0, 0, 1, new Element(H, 2), new Element(O)),
     carbonDioxide(2, "Carbon Dioxide", new Element(C), new Element(O, 2)),
     nitrogenDioxide(3, "Nitrogen Dioxide", new Element(N), new Element(O, 2)),

--- a/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
+++ b/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
@@ -18,7 +18,7 @@ public enum EnumMolecule {
     toluene(4, "Toluene", 1, 1, 1, 0.8F, 0.8F, 0.8F, new Element(C, 7), new Element(H, 8)),
     potassiumNitrate(5, "Potassium Nitrate", 0.9F, 0.9F, 0.9F, 0.8F, 0.8F, 0.8F, new Element(K), new Element(N), new Element(O, 3)),
     tnt(6, "Trinitrotoluene", 1, 1, 0, 1, 0.65F, 0, new Element(C, 6), new Element(H, 2), new Molecule(nitrogenDioxide, 3), new Molecule(toluene)),
-    siliconDioxide(7, "Silicon Dioxide", new Element(Si), new Element(O, 2)),
+    siliconDioxide(7, "Silicon Dioxide", 1, 1, 1, 1, 1, 1, new Element(Si), new Element(O, 2)),
     calcite(8, "Calcite", new Element(Ca), new Element(C), new Element(O, 3)),
     pyrite(9, "Pyrite", new Element(Fe), new Element(S, 2)),
     nepheline(10, "Nepheline", new Element(Al), new Element(Si), new Element(O, 4)),
@@ -152,8 +152,14 @@ public enum EnumMolecule {
     
     @Deprecated
     EnumMolecule(int id, String descriptiveName, Chemical... chemicals) {
-        this(id, descriptiveName, 0.545f, 0.2705f, 0.0745f, 0, 0, 0, chemicals);
-        // Your molecule will literally look like shit until you give it a proper color code.
+        this(id, descriptiveName, getRandomColor(), getRandomColor(), getRandomColor(), getRandomColor(), getRandomColor(), getRandomColor(), chemicals);
+        // Your molecule will have random colors until you give it a proper color code.
+    }
+    
+    private static float getRandomColor()
+    {
+    	Random random = new Random();
+    	return random.nextFloat();
     }
 
 	public static EnumMolecule getById(int id) {

--- a/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
+++ b/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
@@ -14,7 +14,7 @@ public enum EnumMolecule {
     cellulose(0, "Cellulose", 0, 1, 0, 0, 0.25F, 0, new Element(C, 6), new Element(H, 10), new Element(O, 5)),
     water(1, "Water", 0, 0, 1, 0, 0, 1, new Element(H, 2), new Element(O)),
     carbonDioxide(2, "Carbon Dioxide", 0.5F, 0.5F, 0.5F, 0.25F, 0.25F, 0.25F, new Element(C), new Element(O, 2)),
-    nitrogenDioxide(3, "Nitrogen Dioxide", new Element(N), new Element(O, 2)),
+    nitrogenDioxide(3, "Nitrogen Dioxide", 1, 0.65F, 0, 0.5F, 0.1412F, 0.1843F, new Element(N), new Element(O, 2)),
     toluene(4, "Toluene", new Element(C, 7), new Element(H, 8)),
     potassiumNitrate(5, "Potassium Nitrate", new Element(K), new Element(N), new Element(O, 3)),
     tnt(6, "Trinitrotoluene", new Element(C, 6), new Element(H, 2), new Molecule(nitrogenDioxide, 3), new Molecule(toluene)),

--- a/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
+++ b/src/minecraft/ljdp/minechem/api/core/EnumMolecule.java
@@ -12,7 +12,7 @@ import java.util.Random;
 // MOLECULE IDS MUST BE CONTINIOUS OTHERWISE THE ARRAY WILL BE MISALIGNED.
 public enum EnumMolecule {
     cellulose(0, "Cellulose", new Element(C, 6), new Element(H, 10), new Element(O, 5)),
-    water(1, "Water", new Element(H, 2), new Element(O)),
+    water(1, "Water", 0, 0, 1, 0, 0, 1, new Element(H, 2), new Element(O)),
     carbonDioxide(2, "Carbon Dioxide", new Element(C), new Element(O, 2)),
     nitrogenDioxide(3, "Nitrogen Dioxide", new Element(N), new Element(O, 2)),
     toluene(4, "Toluene", new Element(C, 7), new Element(H, 8)),
@@ -127,6 +127,7 @@ public enum EnumMolecule {
     private final String descriptiveName;
     private final ArrayList<Chemical> components;
     private int id;
+    private final Random random = new Random(id);
     public float red;
     public float green;
     public float blue;
@@ -134,23 +135,29 @@ public enum EnumMolecule {
     public float green2;
     public float blue2;
 
-    EnumMolecule(int id, String descriptiveName, Chemical... chemicals) {
+    EnumMolecule(int id, String descriptiveName, float colorRed, float colorGreen, float colorBlue, float colorRed2, float colorGreen2, float colorBlue2, Chemical... chemicals) {
         this.id = id;
         this.components = new ArrayList<Chemical>();
         this.descriptiveName = descriptiveName;
         for (Chemical chemical : chemicals) {
             this.components.add(chemical);
         }
-        Random random = new Random(id); // TODO: Default to random color if molecule is not in color lookup table 
-        this.red = random.nextFloat();
-        this.green = random.nextFloat();
-        this.blue = random.nextFloat();
-        this.red2 = random.nextFloat();
-        this.green2 = random.nextFloat();
-        this.blue2 = random.nextFloat();
+        Random random = new Random(id);
+        this.red = colorRed;
+        this.green = colorGreen;
+        this.blue = colorBlue;
+        this.red2 = colorRed2;
+        this.green2 = colorGreen2;
+        this.blue2 = colorBlue2;
+    }
+    
+    @Deprecated
+    EnumMolecule(int id, String descriptiveName, Chemical... chemicals) {
+        this(id, descriptiveName, 0.545f, 0.2705f, 0.0745f, 0, 0, 0, chemicals);
+        // Your molecule will literally look like shit until you give it a proper color code.
     }
 
-    public static EnumMolecule getById(int id) {
+	public static EnumMolecule getById(int id) {
         for (EnumMolecule molecule : molecules) {
             if (molecule.id == id)
                 return molecule;


### PR DESCRIPTION
Deprecating the add the method used to register molecules before and replaced with one that requires RGB color values to color the molecules.
The deprecated method when called will supply the newer method with random RGB color values.
Currently colored molecules:
Water ( As originally requested by @MFernflower )
Cellulose
Carbon Dioxide
Nitrogen Dioxide
Toluene
Potassium Nitrate
Trinitrotoluene

Comment below if you wish that I color more molecules.
