### PR TITLE
Enabled basic dragging and click-to-scroll in Chemist Journal

### DIFF
--- a/src/ljdp/minechem/client/gui/GuiChemistJournal.java
+++ b/src/ljdp/minechem/client/gui/GuiChemistJournal.java
@@ -356,14 +356,15 @@ public class GuiChemistJournal extends GuiContainerTabbed implements IVerticalSc
     @Override
     public void handleMouseInput() {
         super.handleMouseInput();
-    	if (isScrollBarActive()) {
-    		scrollBar.handleMouseInput();
-    	}    		
-
         int i = Mouse.getEventX() * this.width / this.mc.displayWidth;
         int j = this.height - Mouse.getEventY() * this.height / this.mc.displayHeight - 1;
         mouseX = i - (width - xSize) / 2;
         mouseY = j - (height - ySize) / 2;
+        if (isScrollBarActive() && scrollBar.pointInScrollBar(mouseX, mouseY)) {
+            scrollBar.handleMouseInput();
+        }
+
+
     }
 
     @Override

--- a/src/ljdp/minechem/client/gui/GuiChemistJournal.java
+++ b/src/ljdp/minechem/client/gui/GuiChemistJournal.java
@@ -356,6 +356,10 @@ public class GuiChemistJournal extends GuiContainerTabbed implements IVerticalSc
     @Override
     public void handleMouseInput() {
         super.handleMouseInput();
+    	if (isScrollBarActive()) {
+    		scrollBar.handleMouseInput();
+    	}    		
+
         int i = Mouse.getEventX() * this.width / this.mc.displayWidth;
         int j = this.height - Mouse.getEventY() * this.height / this.mc.displayHeight - 1;
         mouseX = i - (width - xSize) / 2;

--- a/src/ljdp/minechem/client/gui/GuiVerticalScrollBar.java
+++ b/src/ljdp/minechem/client/gui/GuiVerticalScrollBar.java
@@ -6,7 +6,6 @@ import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.util.ResourceLocation;
@@ -17,11 +16,14 @@ public class GuiVerticalScrollBar extends Gui {
     IVerticalScrollContainer container;
     int mouseX;
     int mouseY;
+    // Width, height of the scrollbar slider.
     int width = 12;
     int height = 15;
+    // Current X, Y position of the scrollbar slider.
     int xpos;
     int ypos;
     int startingYPos;
+    // Max Y Displacement of the scrollbar slider.
     int maxDisplacement;
     float scaleFactor;
     float scrollValue = 0.0F;
@@ -72,6 +74,17 @@ public class GuiVerticalScrollBar extends Gui {
         return x >= xpos && x <= xpos + width && y >= ypos && y <= ypos + height;
     }
 
+    /**
+     * Returns true iff the given GUI-relative point is within the scrollbar.
+     * @param x X coordinate relative to the parent container.
+     * @param y Y coordinate relative to the parent container.
+     * @return True iff the coordinates are within this scrollbar.
+     */
+    public boolean pointInScrollBar(int x, int y) {
+        return x >= xpos && x <= xpos + width && y >= startingYPos
+                && y <= startingYPos + maxDisplacement + height;
+    }
+
     public void setYPos(int y) {
         this.ypos = y;
         if (ypos < startingYPos)
@@ -86,7 +99,7 @@ public class GuiVerticalScrollBar extends Gui {
             // Clicking on the slider starts dragging it.
             if (pointIntersects(mouseX, mouseY)) {
                 isDragging = true;
-            } else {
+            } else if (pointInScrollBar(mouseX, mouseY) ) {
                 // Move the slider one slider-height up or down.
                 int scrollAmount = height;
                 if (mouseY < ypos) {

--- a/src/ljdp/minechem/client/gui/GuiVerticalScrollBar.java
+++ b/src/ljdp/minechem/client/gui/GuiVerticalScrollBar.java
@@ -82,8 +82,21 @@ public class GuiVerticalScrollBar extends Gui {
     }
 
     private void onMouseClick() {
-        if (container.isScrollBarActive() && pointIntersects(mouseX, mouseY)) {
-            isDragging = true;
+        if (container.isScrollBarActive()) {
+            // Clicking on the slider starts dragging it.
+            if (pointIntersects(mouseX, mouseY)) {
+                isDragging = true;
+            } else {
+                // Move the slider one slider-height up or down.
+                int scrollAmount = height;
+                if (mouseY < ypos) {
+                    // Up.
+                    setYPos(ypos - scrollAmount);
+                } else if (mouseY > ypos + height) {
+                    // Down.
+                    setYPos(ypos + scrollAmount);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
It's not the most elegant approach, but it does enable use of the scroll bar in the Chemist Journal.

It has the side effect of scrolling the list of items when clicking on one (not so good). Fix incoming.
