### PR TITLE
Cleanup of how Minechem container blocks drop their inventory when broken.

### DIFF
--- a/src/ljdp/minechem/common/blocks/BlockDecomposer.java
+++ b/src/ljdp/minechem/common/blocks/BlockDecomposer.java
@@ -1,7 +1,6 @@
 package ljdp.minechem.common.blocks;
 
 import java.util.ArrayList;
-import java.util.Random;
 
 import ljdp.minechem.common.CommonProxy;
 import ljdp.minechem.common.ModMinechem;
@@ -9,10 +8,8 @@ import ljdp.minechem.common.tileentity.TileEntityDecomposer;
 import ljdp.minechem.common.utils.ConstantValue;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IconRegister;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Icon;
 import net.minecraft.world.World;
@@ -78,56 +75,4 @@ public class BlockDecomposer extends BlockMinechemContainer {
     public boolean isOpaqueCube() {
         return false;
     }
-    
-    
-    
-    
-    Random random=new Random();
-    @Override
-    public void breakBlock(World par1World, int par2, int par3, int par4, int par5, int par6)
-    {
-        TileEntityDecomposer tileentitychest = (TileEntityDecomposer)par1World.getBlockTileEntity(par2, par3, par4);
-
-        if (tileentitychest != null)
-        {
-            for (int j1 = 0; j1 < tileentitychest.getSizeInventory(); ++j1)
-            {
-                ItemStack itemstack = tileentitychest.getStackInSlot(j1);
-
-                if (itemstack != null)
-                {
-                    float f = this.random.nextFloat() * 0.8F + 0.1F;
-                    float f1 = this.random.nextFloat() * 0.8F + 0.1F;
-                    EntityItem entityitem;
-
-                    for (float f2 = this.random.nextFloat() * 0.8F + 0.1F; itemstack.stackSize > 0; par1World.spawnEntityInWorld(entityitem))
-                    {
-                        int k1 = this.random.nextInt(21) + 10;
-
-                        if (k1 > itemstack.stackSize)
-                        {
-                            k1 = itemstack.stackSize;
-                        }
-
-                        itemstack.stackSize -= k1;
-                        entityitem = new EntityItem(par1World, (double)((float)par2 + f), (double)((float)par3 + f1), (double)((float)par4 + f2), new ItemStack(itemstack.itemID, k1, itemstack.getItemDamage()));
-                        float f3 = 0.05F;
-                        entityitem.motionX = (double)((float)this.random.nextGaussian() * f3);
-                        entityitem.motionY = (double)((float)this.random.nextGaussian() * f3 + 0.2F);
-                        entityitem.motionZ = (double)((float)this.random.nextGaussian() * f3);
-
-                        if (itemstack.hasTagCompound())
-                        {
-                            entityitem.getEntityItem().setTagCompound((NBTTagCompound)itemstack.getTagCompound().copy());
-                        }
-                    }
-                }
-            }
-
-            par1World.func_96440_m(par2, par3, par4, par5);
-        }
-
-        super.breakBlock(par1World, par2, par3, par4, par5, par6);
-    }
-
 }

--- a/src/ljdp/minechem/common/blocks/BlockMinechemContainer.java
+++ b/src/ljdp/minechem/common/blocks/BlockMinechemContainer.java
@@ -7,6 +7,7 @@ import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
@@ -24,7 +25,7 @@ public abstract class BlockMinechemContainer extends BlockContainer {
     public abstract void addStacksDroppedOnBlockBreak(TileEntity tileEntity, ArrayList<ItemStack> itemStacks);
 
     @Override
-    public void breakBlock(World world, int x, int y, int z, int par5, int par6) {
+    public void breakBlock(World world, int x, int y, int z, int oldBlockId, int oldMetadata) {
         TileEntity tileEntity = world.getBlockTileEntity(x, y, z);
         if (tileEntity != null) {
             ArrayList<ItemStack> droppedStacks = new ArrayList<ItemStack>();
@@ -38,12 +39,24 @@ public abstract class BlockMinechemContainer extends BlockContainer {
                     if (randomN > itemstack.stackSize)
                         randomN = itemstack.stackSize;
                     itemstack.stackSize -= randomN;
-                    new EntityItem(world, (double) ((float) x + randomX), (double) ((float) y + randomY), (double) ((float) z + randomZ), new ItemStack(
-                            itemstack.itemID, randomN, itemstack.getItemDamage()));
+                    ItemStack droppedStack = new ItemStack(itemstack.itemID, randomN,
+                            itemstack.getItemDamage());
+                    // Copy NBT tag data, needed to preserve Chemist Journal
+                    // contents (for example).
+                    if (itemstack.hasTagCompound()) {
+                        droppedStack.setTagCompound(
+                                (NBTTagCompound) itemstack.getTagCompound().copy());
+                    }
 
+                    EntityItem droppedEntityItem = new EntityItem(world,
+                            (double) ((float) x + randomX),
+                            (double) ((float) y + randomY),
+                            (double) ((float) z + randomZ),
+                            droppedStack);
+                    world.spawnEntityInWorld(droppedEntityItem);
                 }
             }
-            super.breakBlock(world, x, y, z, par5, par6);
+            super.breakBlock(world, x, y, z, oldBlockId, oldMetadata);
         }
 
     }

--- a/src/ljdp/minechem/common/blocks/BlockSynthesis.java
+++ b/src/ljdp/minechem/common/blocks/BlockSynthesis.java
@@ -1,21 +1,26 @@
 package ljdp.minechem.common.blocks;
 
 import java.util.ArrayList;
-import java.util.Random;
 
 import ljdp.minechem.common.CommonProxy;
 import ljdp.minechem.common.ModMinechem;
 import ljdp.minechem.common.tileentity.TileEntitySynthesis;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
+/**
+ * Chemical Synthesizer block. Its associated TileEntitySynthesis's inventory
+ * inventory has many specialized slots, including some "ghost" slots whose
+ * contents don't really exist and shouldn't be able to be extracted or dumped
+ * when the block is broken.
+ * See {@link ljdp.minechem.common.tileentity.TileEntitySynthesis} for details
+ * of the inventory slots.
+ */
 public class BlockSynthesis extends BlockMinechemContainer {
 
     public BlockSynthesis(int par1) {
@@ -39,53 +44,6 @@ public class BlockSynthesis extends BlockMinechemContainer {
         entityPlayer.openGui(ModMinechem.instance, 0, world, x, y, z);
         return true;
     }
-    Random random=new Random();
-    @Override
-    public void breakBlock(World par1World, int par2, int par3, int par4, int par5, int par6)
-    {
-        TileEntitySynthesis tileentitychest = (TileEntitySynthesis)par1World.getBlockTileEntity(par2, par3, par4);
-
-        if (tileentitychest != null)
-        {
-            for (int j1 = 0; j1 < tileentitychest.getSizeInventory(); ++j1)
-            {
-                ItemStack itemstack = tileentitychest.getStackInSlot(j1);
-
-                if (itemstack != null)
-                {
-                    float f = this.random.nextFloat() * 0.8F + 0.1F;
-                    float f1 = this.random.nextFloat() * 0.8F + 0.1F;
-                    EntityItem entityitem;
-
-                    for (float f2 = this.random.nextFloat() * 0.8F + 0.1F; itemstack.stackSize > 0; par1World.spawnEntityInWorld(entityitem))
-                    {
-                        int k1 = this.random.nextInt(21) + 10;
-
-                        if (k1 > itemstack.stackSize)
-                        {
-                            k1 = itemstack.stackSize;
-                        }
-
-                        itemstack.stackSize -= k1;
-                        entityitem = new EntityItem(par1World, (double)((float)par2 + f), (double)((float)par3 + f1), (double)((float)par4 + f2), new ItemStack(itemstack.itemID, k1, itemstack.getItemDamage()));
-                        float f3 = 0.05F;
-                        entityitem.motionX = (double)((float)this.random.nextGaussian() * f3);
-                        entityitem.motionY = (double)((float)this.random.nextGaussian() * f3 + 0.2F);
-                        entityitem.motionZ = (double)((float)this.random.nextGaussian() * f3);
-
-                        if (itemstack.hasTagCompound())
-                        {
-                            entityitem.getEntityItem().setTagCompound((NBTTagCompound)itemstack.getTagCompound().copy());
-                        }
-                    }
-                }
-            }
-
-            par1World.func_96440_m(par2, par3, par4, par5);
-        }
-
-        super.breakBlock(par1World, par2, par3, par4, par5, par6);
-    }
 
     @Override
     public TileEntity createNewTileEntity(World var1) {
@@ -93,18 +51,18 @@ public class BlockSynthesis extends BlockMinechemContainer {
     }
 
     @Override
-	public void addStacksDroppedOnBlockBreak(TileEntity tileEntity, ArrayList itemStacks) {
-		TileEntitySynthesis decomposer = (TileEntitySynthesis)tileEntity;
-		for(int slot:decomposer.kRealSlots) {
-			if(slot >= decomposer.kStartRecipe && slot < decomposer.kStartRecipe + decomposer.kSizeRecipe)
-				continue;
-			ItemStack itemstack = decomposer.getStackInSlot(slot);
-			if(itemstack != null) {
-				itemStacks.add(itemstack);
-			}
-		}
-		return;
-	}
+    public void addStacksDroppedOnBlockBreak(TileEntity tileEntity,
+            ArrayList itemStacks) {
+        TileEntitySynthesis synthesizer = (TileEntitySynthesis) tileEntity;
+        for (int slot : synthesizer.kRealSlots) {
+            if (synthesizer.isRealItemSlot(slot)) {
+                ItemStack itemstack = synthesizer.getStackInSlot(slot);
+                if (itemstack != null) {
+                    itemStacks.add(itemstack);
+                }
+            }
+        }
+    }
 
     @Override
     public boolean isOpaqueCube() {

--- a/src/ljdp/minechem/common/tileentity/TileEntitySynthesis.java
+++ b/src/ljdp/minechem/common/tileentity/TileEntitySynthesis.java
@@ -53,8 +53,29 @@ public class TileEntitySynthesis extends MinechemTileEntity implements ISidedInv
     public static final int[] kStorage = { 14, 15, 16, 17, 18, 19, 20, 21, 22 };
     public static final int[] kJournal = { 23 };
     //Slots that contain *real* items
-    //For the purpose of dropping upon break
-    public static final int[] kRealSlots={10,11,12,13,14, 15, 16, 17, 18, 19, 20, 21, 22 ,23};
+    //For the purpose of dropping upon break. These are bottles, storage, and 
+    // journal.
+    public static final int[] kRealSlots;
+    
+    // Ensure that the list of real slots stays in sync with the above defs.
+    static {
+        ArrayList l = new ArrayList();
+        for (int v : kBottles) {
+            l.add(v);
+        }
+        for (int v : kStorage) {
+            l.add(v);
+        }
+        for (int v : kJournal) {
+            l.add(v);
+        }
+        kRealSlots = new int[l.size()];
+        for (int idx = 0; idx < l.size(); idx++) {
+            // Jump through some autounboxing hoops due to primitive types not 
+            // being first-class types.
+            kRealSlots[idx] = (Integer) l.get(idx);
+        }
+    }
 
     private SynthesisRecipe currentRecipe;
     public ModelSynthesizer model;
@@ -112,6 +133,61 @@ public class TileEntitySynthesis extends MinechemTileEntity implements ISidedInv
 
     @Override
     public void closeChest() {}
+    
+    private boolean valueIn(int value, int[] arr) {
+        if (arr == null) {
+            return false;
+        }
+        for (int v : arr) {
+            if (value == v) {
+                return true;
+            }
+        }
+        return false;
+    }
+    /**
+     * Returns true iff the given inventory slot is a "ghost" slot used
+     * to show the output of the configured recipe. Ghost output items don't
+     * really exist and should never be dumped or extracted, except when the
+     * recipe is crafted.
+     * @param slotId Slot Id to check.
+     * @return true iff the slot is a "ghost" slot for the recipe output.
+     */
+    public boolean isGhostOutputSlot(int slotId) {
+        return valueIn(slotId, kOutput);
+    }
+
+    /**
+     * Returns true iff the given inventory slot is a "ghost" slot used to show
+     * the inputs of a crafting recipe. Items in these slots don't really exist
+     * and should never be dumped or extracted.
+     * 
+     * @param slotId Slot Id to check.
+     * @return true iff the slot is a "ghost" slot for the recipe.
+     */
+    public boolean isGhostCraftingRecipeSlot(int slotId) {
+        return valueIn(slotId, kRecipe);
+    }
+
+    /**
+     * Returns true iff the given inventory slot holds a "ghost" item
+     * that doesn't really exist.
+     * @param slotId Slot Id to check.
+     * @return true iff the slot holds a "ghost" item.
+     */
+    public boolean isGhostSlot(int slotId) {
+        return isGhostOutputSlot(slotId) || isGhostCraftingRecipeSlot(slotId);
+    }
+
+    /**
+     * Returns true iff the given inventory slot can hold a real (non-ghost)
+     * item, i.e., one that is really stored in the inventory.
+     * @param slotId Slot Id to check.
+     * @return true iff the slot can hold a real item.
+     */
+    public boolean isRealItemSlot(int slotId) {
+        return !isGhostSlot(slotId);
+    }
 
     @Override
     public ItemStack decrStackSize(int slot, int amount) {

--- a/test/README.txt
+++ b/test/README.txt
@@ -1,0 +1,5 @@
+
+This directory contains tests for MineChem code. Running them requires
+EasyMock, PowerMock, and JUnit4.
+
+Test classes should not be included in any MineChem release.

--- a/test/ljdp/minechem/common/blocks/BlockMinechemContainerTest.java
+++ b/test/ljdp/minechem/common/blocks/BlockMinechemContainerTest.java
@@ -1,0 +1,226 @@
+package ljdp.minechem.common.blocks;
+
+import java.util.ArrayList;
+
+import ljdp.minechem.common.items.ItemChemistJournal;
+import ljdp.minechem.utils.test.EntityItemMatcher;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.logging.ILogAgent;
+import net.minecraft.profiler.Profiler;
+import net.minecraft.stats.StatList;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.EnumGameType;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.storage.ISaveHandler;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import cpw.mods.fml.common.registry.GameData;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.FMLInjectionData;
+
+/**
+ * Unit tests for BlockMinechemContainer.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ GameData.class, GameRegistry.class, StatList.class,
+        FMLInjectionData.class })
+public class BlockMinechemContainerTest {
+    
+    public static class TestableBlockMinechemContainer 
+        extends BlockMinechemContainer {
+        
+        private ArrayList<ItemStack> stacksDroppedOnBlockBreak;
+        
+        public TestableBlockMinechemContainer() {
+            super(DUMMY_BLOCKID, DUMMY_MATERIAL);
+            stacksDroppedOnBlockBreak = new ArrayList<ItemStack>();
+        }
+
+        @Override
+        public TileEntity createNewTileEntity(World world) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+        
+        public void resetTestingState() {
+            stacksDroppedOnBlockBreak = new ArrayList<ItemStack>();
+        }
+        
+        public void setStacksToDropForTest(ArrayList<ItemStack> stacksToDrop) {
+            stacksDroppedOnBlockBreak = stacksToDrop;
+        }
+
+        @Override
+        public void addStacksDroppedOnBlockBreak(TileEntity tileEntity,
+                ArrayList<ItemStack> itemStacks) {
+            if (itemStacks != null) {
+                itemStacks.addAll(stacksDroppedOnBlockBreak);
+            }
+        }
+    }
+
+    
+
+
+    private static final int DUMMY_BLOCKID = 4000;
+    private static final int DUMMY_JOURNALID = 16000;
+    private static final Material DUMMY_MATERIAL = Material.iron;
+    private static final int DUMMY_X = 0;
+    private static final int DUMMY_Y = 1;
+    private static final int DUMMY_Z = 2;
+    
+    // A block type must be instantiated only once (as it registers its ID).
+    // The instance is reused across tests, and its associated test data
+    // must be reset per test.
+    private static TestableBlockMinechemContainer bmc = null;
+    
+    // A mock World used in tests.
+    private World mockWorld;
+    
+    @Before
+    public void setUp() {
+        // Set up static method stubs to avoid having to instantiate all of
+        // Minecraft+Forge
+        PowerMock.mockStatic(GameData.class);
+        PowerMock.mockStaticNice(GameRegistry.class);
+        PowerMock.mockStatic(StatList.class);
+        PowerMock.mockStatic(FMLInjectionData.class);
+        
+        // Expect any number of GameData.newItemAdded calls.
+        GameData.newItemAdded(EasyMock.anyObject(Item.class));
+        PowerMock.expectLastCall().anyTimes();
+        
+        WorldProvider wp = new WorldProvider() {
+
+            @Override
+            public String getDimensionName() {
+                return "DummyDimension";
+            }
+        };
+        WorldSettings ws = new WorldSettings(0L, EnumGameType.SURVIVAL, 
+                false, false, WorldType.DEFAULT);
+            
+        mockWorld = EasyMock.createMockBuilder(World.class)
+                .withConstructor(ISaveHandler.class, String.class, 
+                        WorldProvider.class, WorldSettings.class, 
+                        Profiler.class, ILogAgent.class)
+                .withArgs((ISaveHandler) null, "", wp, ws,
+                        (Profiler) null, (ILogAgent) null)
+                        .addMockedMethod("getBlockTileEntity")
+                        .addMockedMethod("removeBlockTileEntity")
+                        .addMockedMethod("spawnEntityInWorld")
+                        .createMock();
+        // Reset testing state of the testable block instance, creating it
+        // if necessary. It must be created only once, as it registers its Id
+        // in the global block array. Creation is deferred to ensure that
+        // necessary static mocking has been completed.
+        if (bmc == null) {
+            bmc = new TestableBlockMinechemContainer();
+        }
+        bmc.resetTestingState();
+    }
+
+    /**
+     * Tests when no items are dropped from the block.
+     */
+    @Test
+    public void testBreakBlockNoDrops() {
+        TileEntity dummyTileEntity = new TileEntity();
+        // The TileEntity should be fetched once, but no items should be added
+        // to the world as none are dropped by the block.
+        EasyMock.expect(mockWorld.getBlockTileEntity(DUMMY_X, DUMMY_Y, DUMMY_Z))
+            .andReturn(dummyTileEntity);
+        mockWorld.removeBlockTileEntity(DUMMY_X, DUMMY_Y, DUMMY_Z);
+        EasyMock.expectLastCall();
+        
+        // Drop no items.
+        ArrayList<ItemStack> itemsToDrop = new ArrayList<ItemStack>();
+        bmc.setStacksToDropForTest(itemsToDrop);
+        
+        PowerMock.replay(GameData.class, GameRegistry.class, StatList.class,
+                FMLInjectionData.class);
+        EasyMock.replay(mockWorld);
+
+        bmc.breakBlock(mockWorld, DUMMY_X, DUMMY_Y, DUMMY_Z, DUMMY_BLOCKID, 0);
+        EasyMock.verify(mockWorld);
+    }
+    
+    /**
+     * Tests that NBT data is preserved in any dropped blocks.
+     */
+    @Test
+    public void testBreakBlockNBTDrops() {
+        TileEntity dummyTileEntity = new TileEntity();
+        // The TileEntity should be fetched once, and a journal with matching
+        // NBT data should be dropped.
+        EasyMock.expect(mockWorld.getBlockTileEntity(DUMMY_X, DUMMY_Y, DUMMY_Z))
+            .andReturn(dummyTileEntity);
+        mockWorld.removeBlockTileEntity(DUMMY_X, DUMMY_Y, DUMMY_Z);
+        EasyMock.expectLastCall();
+
+        ArrayList<ItemStack> itemsToDrop = new ArrayList<ItemStack>();
+        ItemChemistJournal journal = new ItemChemistJournal(DUMMY_JOURNALID);
+        ItemStack itemstack = new ItemStack(Item.flint);
+        ItemStack journalItemStack = new ItemStack(journal);
+        journal.addItemStackToJournal(itemstack, journalItemStack, mockWorld);
+        itemsToDrop.add(journalItemStack);
+        
+        // Drop one item with NBT data, and expect it to be dropped.
+        bmc.setStacksToDropForTest(itemsToDrop);
+        EasyMock.expect(mockWorld.spawnEntityInWorld(
+                EntityItemMatcher.eqEntityItem(journalItemStack))).andReturn(true);
+
+        PowerMock.replay(GameData.class, GameRegistry.class, StatList.class,
+                FMLInjectionData.class);
+        EasyMock.replay(mockWorld);
+
+        bmc.breakBlock(mockWorld, DUMMY_X, DUMMY_Y, DUMMY_Z, DUMMY_BLOCKID, 0);
+        EasyMock.verify(mockWorld);
+    }
+    
+    /**
+     * Tests when items are dropped from the block.
+     */
+    @Test
+    public void testBreakBlockDrops() {
+        TileEntity dummyTileEntity = new TileEntity();
+        // The TileEntity should be fetched once, and several items should drop.
+        EasyMock.expect(mockWorld.getBlockTileEntity(DUMMY_X, DUMMY_Y, DUMMY_Z))
+            .andReturn(dummyTileEntity);
+        mockWorld.removeBlockTileEntity(DUMMY_X, DUMMY_Y, DUMMY_Z);
+        EasyMock.expectLastCall();
+
+        ArrayList<ItemStack> itemsToDrop = new ArrayList<ItemStack>();
+        itemsToDrop.add(new ItemStack(Item.flint));
+        itemsToDrop.add(new ItemStack(Item.coal, 4));
+        itemsToDrop.add(new ItemStack(Block.sapling, 10, 2));
+        
+        bmc.setStacksToDropForTest(itemsToDrop);
+        EasyMock.expect(mockWorld.spawnEntityInWorld(
+                EntityItemMatcher.eqEntityItem(itemsToDrop.get(0)))).andReturn(true);
+        EasyMock.expect(mockWorld.spawnEntityInWorld(
+                EntityItemMatcher.eqEntityItem(itemsToDrop.get(1)))).andReturn(true);
+        EasyMock.expect(mockWorld.spawnEntityInWorld(
+                EntityItemMatcher.eqEntityItem(itemsToDrop.get(2)))).andReturn(true);
+        
+        PowerMock.replay(GameData.class, GameRegistry.class, StatList.class,
+                FMLInjectionData.class);
+        EasyMock.replay(mockWorld);
+
+        bmc.breakBlock(mockWorld, DUMMY_X, DUMMY_Y, DUMMY_Z, DUMMY_BLOCKID, 0);
+        EasyMock.verify(mockWorld);
+    }
+}

--- a/test/ljdp/minechem/common/blocks/BlockMinechemContainerTest.java
+++ b/test/ljdp/minechem/common/blocks/BlockMinechemContainerTest.java
@@ -72,9 +72,6 @@ public class BlockMinechemContainerTest {
         }
     }
 
-    
-
-
     private static final int DUMMY_BLOCKID = 4000;
     private static final int DUMMY_JOURNALID = 16000;
     private static final Material DUMMY_MATERIAL = Material.iron;
@@ -204,6 +201,10 @@ public class BlockMinechemContainerTest {
         EasyMock.expectLastCall();
 
         ArrayList<ItemStack> itemsToDrop = new ArrayList<ItemStack>();
+        
+        // Note that the size randomization logic in BlockMinechemContainer
+        // may make these tests fail, if the stack sizes are large enough
+        // to be split by the randomization.
         itemsToDrop.add(new ItemStack(Item.flint));
         itemsToDrop.add(new ItemStack(Item.coal, 4));
         itemsToDrop.add(new ItemStack(Block.sapling, 10, 2));

--- a/test/ljdp/minechem/common/blocks/BlockSynthesisTest.java
+++ b/test/ljdp/minechem/common/blocks/BlockSynthesisTest.java
@@ -1,0 +1,210 @@
+package ljdp.minechem.common.blocks;
+
+import static org.junit.Assert.fail;
+import ljdp.minechem.api.core.EnumElement;
+import ljdp.minechem.common.items.ItemChemistJournal;
+import ljdp.minechem.common.items.ItemElement;
+import ljdp.minechem.common.items.ItemTestTube;
+import ljdp.minechem.common.tileentity.TileEntitySynthesis;
+import ljdp.minechem.utils.test.EntityItemMatcher;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.logging.ILogAgent;
+import net.minecraft.profiler.Profiler;
+import net.minecraft.stats.StatList;
+import net.minecraft.world.EnumGameType;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.storage.ISaveHandler;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.ICrashCallable;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.registry.GameData;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.FMLInjectionData;
+import cpw.mods.fml.relauncher.Side;
+
+/**
+ * Unit tests for BlockSynthesis (chemical synthesis machine).
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ GameData.class, GameRegistry.class, StatList.class,
+        FMLInjectionData.class, FMLCommonHandler.class, Loader.class })
+public class BlockSynthesisTest {
+
+    private static final int DUMMY_BLOCKID = 4000;
+    private static final int DUMMY_JOURNALID = 16000;
+    private static final int DUMMY_TESTTUBEID = 16001;
+    private static final int DUMMY_ELEMENTID = 16002;
+    private static final int DUMMY_X = 0;
+    private static final int DUMMY_Y = 1;
+    private static final int DUMMY_Z = 2;
+
+    private World mockWorld;
+    private Loader mockLoader;
+    
+    private static BlockSynthesis synthesisBlock;
+    private static ItemChemistJournal chemistJournalItem;
+    private static ItemTestTube testTubeItem;
+    private static ItemElement elementItem;
+    private static boolean itemsRegistered = false;
+    private TileEntitySynthesis synthesisTileEntity;
+    
+    // Block and item Ids can only be registered once, as they populate
+    // a global array. Registration must happen as late as feasible, to ensure
+    // that all mock objects are properly configured.
+    private static void registerItems() {
+        if (itemsRegistered) {
+            return;
+        }
+        synthesisBlock = new BlockSynthesis(DUMMY_BLOCKID);
+        chemistJournalItem = new ItemChemistJournal(DUMMY_JOURNALID);
+        testTubeItem = new ItemTestTube(DUMMY_TESTTUBEID);
+        elementItem = new ItemElement(DUMMY_ELEMENTID);
+        itemsRegistered = true;
+    }
+    
+    @Before
+    public void setUp() {
+        // Set up static method stubs to avoid having to instantiate all of
+        // Minecraft+Forge. Mock setup is particularly icky due to the heavy
+        // use of static singletons throughout both Minecraft and Forge;
+        // a mix of static mocks, partial mocks, and fakes is needed.
+        mockLoader = EasyMock.createMockBuilder(Loader.class)
+            .addMockedMethod("getCallableCrashInformation").createMock();
+        PowerMock.mockStaticPartial(Loader.class, "instance");
+        
+        PowerMock.mockStatic(Loader.class);
+        PowerMock.mockStatic(GameData.class);
+        PowerMock.mockStaticNice(GameRegistry.class);
+        PowerMock.mockStatic(StatList.class);
+        PowerMock.mockStatic(FMLInjectionData.class);
+        
+        EasyMock.expect(Loader.instance()).andReturn(mockLoader);
+        ICrashCallable mockCrashCallable = EasyMock.createMock(ICrashCallable.class);
+        EasyMock.expect(mockLoader.getCallableCrashInformation()).andReturn(mockCrashCallable);
+        
+        EasyMock.replay(mockLoader);
+        PowerMock.replay(Loader.class);
+        FMLCommonHandler mockFMLCommonHandler = EasyMock.createMockBuilder(
+                FMLCommonHandler.class).addMockedMethod("getSide")
+                .addMockedMethod("getCurrentLanguage").createMock();
+        EasyMock.expect(mockFMLCommonHandler.getSide()).andReturn(Side.SERVER);
+        EasyMock.expect(mockFMLCommonHandler.getCurrentLanguage())
+            .andReturn("en_US").anyTimes();
+        PowerMock.mockStaticPartial(FMLCommonHandler.class, "instance");
+        EasyMock.expect(FMLCommonHandler.instance())
+            .andReturn(mockFMLCommonHandler).anyTimes();
+        EasyMock.replay(mockFMLCommonHandler);
+        PowerMock.replay(FMLCommonHandler.class);
+        
+        // Expect any number of GameData.newItemAdded calls.
+        GameData.newItemAdded(EasyMock.anyObject(Item.class));
+        PowerMock.expectLastCall().anyTimes();
+        
+        WorldProvider fakeWorldProvider = new WorldProvider() {
+
+            @Override
+            public String getDimensionName() {
+                return "DummyDimension";
+            }
+        };
+        WorldSettings fakeWorldSettings = new WorldSettings(
+                0L, EnumGameType.SURVIVAL, false, false, WorldType.DEFAULT);
+            
+        mockWorld = EasyMock.createMockBuilder(World.class)
+                .withConstructor(ISaveHandler.class, String.class,
+                        WorldProvider.class, WorldSettings.class,
+                        Profiler.class, ILogAgent.class)
+                .withArgs((ISaveHandler) null, "", fakeWorldProvider, 
+                        fakeWorldSettings, (Profiler) null, (ILogAgent) null)
+                        .addMockedMethod("getBlockTileEntity")
+                        .addMockedMethod("removeBlockTileEntity")
+                        .addMockedMethod("spawnEntityInWorld")
+                        .createMock();
+
+        registerItems();
+        synthesisTileEntity = new TileEntitySynthesis();
+    }
+
+    @Test
+    public void testBreakBlockDrops() {
+
+        EasyMock.expect(mockWorld.getBlockTileEntity(DUMMY_X, DUMMY_Y, DUMMY_Z))
+            .andReturn(synthesisTileEntity);
+        mockWorld.removeBlockTileEntity(DUMMY_X, DUMMY_Y, DUMMY_Z);
+        EasyMock.expectLastCall();
+
+        // Add some items to every inventory slot.
+        ItemStack itemstack = new ItemStack(Item.flint);
+        ItemStack journalItemStack = new ItemStack(chemistJournalItem);
+        chemistJournalItem.addItemStackToJournal(itemstack, journalItemStack,
+                mockWorld);
+        boolean[] slotUsed = new boolean[synthesisTileEntity.inventory.length];
+        for (int idx: synthesisTileEntity.kJournal) {
+            synthesisTileEntity.inventory[idx] = journalItemStack;
+            slotUsed[idx] = true;
+        }
+        int nItems = 1;
+        for (int idx: synthesisTileEntity.kBottles) {
+            ItemStack bottles = new ItemStack(testTubeItem, nItems++);
+            synthesisTileEntity.inventory[idx] = bottles;
+            slotUsed[idx] = true;
+        }
+        nItems = 1;
+        for (int idx: synthesisTileEntity.kOutput) {
+            ItemStack output = new ItemStack(Item.flint, nItems);
+            synthesisTileEntity.inventory[idx] = output;
+            slotUsed[idx] = true;
+        }
+        nItems = 1;
+        for (int idx: synthesisTileEntity.kRecipe) {
+            ItemStack recipeInput = new ItemStack(elementItem, nItems,
+                    EnumElement.C.ordinal());
+            synthesisTileEntity.inventory[idx] = recipeInput;
+            slotUsed[idx] = true;
+        }
+        nItems = 1;
+        for (int idx: synthesisTileEntity.kStorage) {
+            ItemStack storedItem = new ItemStack(elementItem, nItems,
+                    EnumElement.H.ordinal());
+            synthesisTileEntity.inventory[idx] = storedItem;
+            slotUsed[idx] = true;
+        }
+        
+        // All slots must be populated for the test to be valid.
+        for (int idx = 0; idx < slotUsed.length; idx++) {
+            if (!slotUsed[idx]) {
+                fail("Inventory slot " + idx + " not populated by test");
+            }
+        }
+        
+        // Only "real" slots should have their contents spawned in the world.
+        for (int idx: synthesisTileEntity.kRealSlots) {
+            if (synthesisTileEntity.isGhostSlot(idx)) {
+                fail("Inventory slot " + idx + " is a ghost slot but in real list");
+            }
+            EasyMock.expect(mockWorld.spawnEntityInWorld(
+                    EntityItemMatcher.eqEntityItem(
+                            synthesisTileEntity.inventory[idx]))).andReturn(true);
+        }
+        
+        PowerMock.replay(GameData.class, GameRegistry.class, StatList.class,
+                FMLInjectionData.class, FMLCommonHandler.class);
+        EasyMock.replay(mockWorld);
+
+        synthesisBlock.breakBlock(mockWorld, DUMMY_X, DUMMY_Y, DUMMY_Z, DUMMY_BLOCKID, 0);
+        EasyMock.verify(mockWorld);
+    }
+}

--- a/test/ljdp/minechem/utils/test/EntityItemMatcher.java
+++ b/test/ljdp/minechem/utils/test/EntityItemMatcher.java
@@ -1,0 +1,68 @@
+package ljdp.minechem.utils.test;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.ItemStack;
+
+import org.easymock.EasyMock;
+import org.easymock.IArgumentMatcher;
+
+/**
+ * EasyMock argument matcher that matches a supplied EntityItem's ItemStack
+ * against an expected value. The other aspects of the EntityItem
+ * (such as world and coordinates) are ignored.
+ */
+public class EntityItemMatcher implements IArgumentMatcher {
+    private ItemStack expectedItemStack;
+
+    public EntityItemMatcher(ItemStack expectedItemStack) {
+        this.expectedItemStack = expectedItemStack;
+    }
+
+    @Override
+    public void appendTo(StringBuffer sb) {
+        sb.append("EntityItemMatcher(");
+        sb.append(expectedItemStack.getDisplayName());
+        if (expectedItemStack.stackSize > 1) {
+            sb.append("x").append(expectedItemStack.stackSize);
+        }
+        if (expectedItemStack.hasTagCompound()) {
+            sb.append("[");
+            sb.append(expectedItemStack.getTagCompound());
+            sb.append("]");
+        }
+        sb.append(")");
+    }
+
+    @Override
+    public boolean matches(Object obj) {
+        EntityItem entityItem = (EntityItem) obj;
+        ItemStack itemStack = entityItem.getEntityItem();
+        if (!expectedItemStack.isItemEqual(itemStack)) {
+            return false;
+        }
+        if (expectedItemStack.hasTagCompound()) {
+            if (!itemStack.hasTagCompound()) {
+                return false;
+            }
+            if (!expectedItemStack.getTagCompound().equals(
+                    itemStack.getTagCompound())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Invokes an EasyMock argument matcher that compares an EntityItem's
+     * ItemStack against the expected value.
+     * 
+     * @param expectedItemStack
+     *            Expected ItemStack against which an argument EntityItem's
+     *            ItemStack will be compared.
+     * @return null, as the return value isn't used.
+     */
+    public static EntityItem eqEntityItem(ItemStack expectedItemStack) {
+        EasyMock.reportMatcher(new EntityItemMatcher(expectedItemStack));
+        return null;
+    }
+}


### PR DESCRIPTION
This change fixes a dupe bug (Issue #98) and removes some unused code. It also includes unit tests.
