### PR TITLE
Added display of multi-output and chance-based decomposer recipes. Added...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,11 @@ thirdPartyJarsConfigFile.withReader {
   ext.thirdPartyJars = new ConfigSlurper().parse prop
 }
 
-// This mod has NEI support, so NEI is needed to build it (but not required
-// to use it).
+// This mod has NEI support, so NEI+CodeChickenCore are needed to build
+// it (but not required to use it).
 dependencies {
-  compile files(thirdPartyJars.path + '/' + thirdPartyJars.NEI)
+  compile files(thirdPartyJars.path + '/' + thirdPartyJars.NEI,
+    thirdPartyJars.path + '/' + thirdPartyJars.CodeChickenCore)
 }
 
 

--- a/src/main/java/ljdp/minechem/client/gui/GuiDecomposer.java
+++ b/src/main/java/ljdp/minechem/client/gui/GuiDecomposer.java
@@ -35,7 +35,7 @@ public class GuiDecomposer extends GuiContainerTabbed {
     @Override
     protected void drawGuiContainerForegroundLayer(int par1, int par2) {
         super.drawGuiContainerForegroundLayer(par1, par2);
-        String info = "Chemical Decomposer";
+        String info = MinechemHelper.getLocalString("gui.title.decomposer");
         int infoWidth = fontRenderer.getStringWidth(info);
         fontRenderer.drawString(info, (guiWidth - infoWidth) / 2, 5, 0xCCCCCC);
     }

--- a/src/main/java/ljdp/minechem/client/nei/SynthesisNEIRecipeHandler.java
+++ b/src/main/java/ljdp/minechem/client/nei/SynthesisNEIRecipeHandler.java
@@ -1,11 +1,13 @@
 package ljdp.minechem.client.nei;
 
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 
 import ljdp.minechem.api.core.Chemical;
 import ljdp.minechem.api.recipe.SynthesisRecipe;
 import ljdp.minechem.api.util.Util;
+import ljdp.minechem.client.gui.GuiSynthesis;
 import ljdp.minechem.common.utils.ConstantValue;
 import ljdp.minechem.common.utils.MinechemHelper;
 import net.minecraft.item.ItemStack;
@@ -33,14 +35,27 @@ public class SynthesisNEIRecipeHandler extends TemplateRecipeHandler {
 
     @Override
     public String getRecipeName() {
-        return "Chemical Synthesis";
+        return MinechemHelper.getLocalString("gui.title.synthesis");
     }
 
     @Override
     public String getGuiTexture() {
         return texture.toString();
     }
-    
+
+    @Override
+    public void loadTransferRects() {
+        // Use the right-arrow pointing at the output.
+        transferRects.add(new TemplateRecipeHandler.RecipeTransferRect(
+            new Rectangle(OUTPUT_X_OFS - 16, OUTPUT_Y_OFS, 14, 16),
+            MINECHEM_SYNTHESIS_RECIPES_ID, new Object[0]));
+    }
+
+    @Override
+    public Class getGuiClass() {
+        return GuiSynthesis.class;
+    }
+
     @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
         if (outputId.equals(MINECHEM_SYNTHESIS_RECIPES_ID)) {

--- a/src/main/java/ljdp/minechem/common/polytool/types/PolytoolTypeIron.java
+++ b/src/main/java/ljdp/minechem/common/polytool/types/PolytoolTypeIron.java
@@ -12,8 +12,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
 import net.minecraftforge.oredict.OreDictionary;
 
-import com.sun.jmx.remote.internal.ArrayQueue;
-
 public class PolytoolTypeIron extends PolytoolUpgradeType{
 
 	public PolytoolTypeIron() {

--- a/thirdPartyJars.properties
+++ b/thirdPartyJars.properties
@@ -3,3 +3,6 @@ path = jars/
 
 # The dev jar name for Not Enough Items.
 NEI = NotEnoughItems-dev 1.6.1.8.jar
+
+# The jar for Chickenbones' CodeChickenCore.
+CodeChickenCore = CodeChickenCore 0.9.0.6.jar


### PR DESCRIPTION
... localization for NEI GUI names. Added NEI see-all-recipes click targets for decomposer and synthesis machines.

NOTE: This now requires CodeChickenCore to build (but not run, unless NEI is also present). I did not add the JAR directly to the repo, as it's unclear whether that's the best practice.
