### PR TITLE
Update Chemist Journal to display RF

### DIFF
--- a/src/main/java/pixlepix/minechem/client/gui/GuiChemistJournal.java
+++ b/src/main/java/pixlepix/minechem/client/gui/GuiChemistJournal.java
@@ -298,7 +298,7 @@ public class GuiChemistJournal extends GuiContainerTabbed implements IVerticalSc
         fontRenderer.drawString(MinechemHelper.getLocalString("gui.journal.synthesis"), 175, 100, 0x884400);
         if (currentSynthesisRecipe != null) {
             int energyCost = currentSynthesisRecipe.energyCost();
-            fontRenderer.drawString(String.format("%d MJ", energyCost), 175, 110, 0x555555);
+            fontRenderer.drawString(String.format("%d RF", energyCost), 175, 110, 0x555555);
         }
     }
 


### PR DESCRIPTION
I didn't have time to take a look at your code.
Please take a look: the journal still displays Emeralds' synth cost as 50000 (MJ) and not 5000 (RF).
I don't know if that display value is hard-coded then. It would be nice if it can just look up the value.
